### PR TITLE
Update requirements to match katsdpdockerbase update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pygelf                       # via katsdpservices
 omnijson                     # via katportalclient
 redis                        # via katsdptelstate
 terminaltables               # via aiomonitor
-tornado==6.0.2
+tornado
 ujson                        # via katportalclient
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate


### PR DESCRIPTION
This should be merged together with ska-sa/katsdpdockerbase#46. It may
currently fail to build until that branch is merged.