### PR TITLE
Remove support for "new-style" channel masks

### DIFF
--- a/scripts/cam2telstate.py
+++ b/scripts/cam2telstate.py
@@ -34,22 +34,6 @@ def convert_bitmask(value: object) -> np.ndarray:
         return np.array([c == '1' for c in value])
 
 
-def convert_channel_mask(value: object) -> np.ndarray:
-    """Converts the channel-mask sensor to a numpy array.
-
-    This sensor has two possible formats:
-    - old: single string of 0's and 1's
-    - new: JSON array of strings, each consisting of 0's and 1's
-    """
-    if not isinstance(value, str):
-        return None
-    elif value[0] in ['0', '1']:
-        return convert_bitmask(value)[np.newaxis, :]
-    else:
-        values = json.loads(value)
-        return np.array([[c == '1' for c in row] for row in values])
-
-
 class Template(string.Template):
     """Template for a sensor name."""
 
@@ -238,7 +222,7 @@ SENSORS = [
     Sensor('${subarray}_dump_rate', immutable=True),
     Sensor('${subarray}_pool_resources', immutable=True),
     Sensor('${sub_stream.cbf.antenna_channelised_voltage}_channel_mask',
-           convert=convert_channel_mask),
+           convert=convert_bitmask),
     # TODO: remove ignore_missing once CAM implements this
     Sensor('${sub_stream.cbf.antenna_channelised_voltage}_channel_mask_max_baseline_lengths',
            convert=json.loads, immutable=True, ignore_missing=True),


### PR DESCRIPTION
These were never implemented by CAM and are being abandoned. The
resulting sensor is now 1D instead of 2D again, which requires the
latest katsdpingest.