### PR TITLE
SPP1-180: MKE serial number sensor update

### DIFF
--- a/scripts/cam2telstate.py
+++ b/scripts/cam2telstate.py
@@ -288,9 +288,9 @@ SENSORS = [
 ]
 
 # Mapping from receiver band identity to SPF feed package index number
-BAND_TO_SPF_INDEX = {
-    'l': 2,   # L-band -> SPF2
-    's': 3,   # S-band -> SPF3
+MK_BAND_TO_SKA_MID_BAND = {
+    'l': '2',   # L-band -> SPF2
+    's': '3',   # S-band -> SPF3
 }
 
 
@@ -411,12 +411,7 @@ class Client:
 
         rx_name = 'rsc_rx{}'.format(band)
         dig_name = 'dig_{}_band'.format(band)
-
-        mke_band_substitutions: List[Tuple[str, List[str]]] = []
-        if band in BAND_TO_SPF_INDEX:
-            mke_index = str(BAND_TO_SPF_INDEX[band])
-            mke_band_substitutions.append((mke_index, [mke_index]))
-
+        mke_band = MK_BAND_TO_SKA_MID_BAND.get(band, 'unknown')
         # Build table of names for expanding sensor templates
         substitutions: Dict[str, List[Tuple[str, List[str]]]] = {
             'receptor': [(name, [name]) for name in receptors],
@@ -430,7 +425,7 @@ class Client:
             'stream': [],
             'sub_stream': [],
             'stream.cbf.tied_array_channelised_voltage.inputn': [],
-            'mke_band': mke_band_substitutions
+            'mke_band': [(mke_band, [mke_band])],
         }
         for stream_type in STREAM_TYPES:
             substitutions['stream.' + stream_type] = []

--- a/scripts/cam2telstate.py
+++ b/scripts/cam2telstate.py
@@ -158,6 +158,7 @@ SENSORS = [
     Sensor('${receptor}_ap_tilt_corr_azim'),
     Sensor('${receptor}_ap_tilt_corr_elev'),
     Sensor('${receptor}_${receiver}_serial_number', immutable=True),
+    Sensor('${receptor}_spfc_serialNumbers_${mke_band}', immutable=True, ignore_missing=True),
     Sensor('${receptor}_data_suspect'),
     Sensor('${receptor}_ap_version_list', immutable=True),
     #
@@ -286,6 +287,12 @@ SENSORS = [
     Sensor('mcp_dmc_version_list', immutable=True)
 ]
 
+# Mapping from receiver band identity to SPF feed package index number
+BAND_TO_SPF_INDEX = {
+    'l': 2,   # L-band -> SPF2
+    's': 3,   # S-band -> SPF3
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = katsdpservices.ArgumentParser()
@@ -404,6 +411,12 @@ class Client:
 
         rx_name = 'rsc_rx{}'.format(band)
         dig_name = 'dig_{}_band'.format(band)
+
+        mke_band_substitutions: List[Tuple[str, List[str]]] = []
+        if band in BAND_TO_SPF_INDEX:
+            mke_index = str(BAND_TO_SPF_INDEX[band])
+            mke_band_substitutions.append((mke_index, [mke_index]))
+
         # Build table of names for expanding sensor templates
         substitutions: Dict[str, List[Tuple[str, List[str]]]] = {
             'receptor': [(name, [name]) for name in receptors],
@@ -416,7 +429,8 @@ class Client:
             'instrument': [],
             'stream': [],
             'sub_stream': [],
-            'stream.cbf.tied_array_channelised_voltage.inputn': []
+            'stream.cbf.tied_array_channelised_voltage.inputn': [],
+            'mke_band': mke_band_substitutions
         }
         for stream_type in STREAM_TYPES:
             substitutions['stream.' + stream_type] = []


### PR DESCRIPTION
This PR adds support for collecting MKE   SPFC feed package serial number sensors  from CAM and populate them to telstate. 
Key updates include adding the immutable sensor template, a `BAND_TO_SPF_INDEX` lookup table to map receiver bands to SPF indices (e.g., L-band $\rightarrow$ SPF2), dynamic substitution logic that safely skips unmapped bands.